### PR TITLE
Use sleep from thirtyfour support

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1,13 +1,13 @@
-use tokio::time::{delay_for, Duration, Instant};
-
 use futures::Future;
 use serde::{Deserialize, Serialize};
 use std::mem;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use stringmatch::Needle;
 use thirtyfour::error::{WebDriverError, WebDriverErrorInfo};
 use thirtyfour::prelude::{WebDriver, WebDriverResult};
+use thirtyfour::support::sleep;
 use thirtyfour::{By, WebDriverCommands, WebDriverSession, WebElement};
 
 /// Get String containing comma-separated list of selectors used.
@@ -363,7 +363,7 @@ impl<'a> ElementQuery<'a> {
 
                 if actual_elapsed < minimum_elapsed {
                     // So we need to wait this much longer.
-                    delay_for(minimum_elapsed - actual_elapsed).await;
+                    sleep(minimum_elapsed - actual_elapsed).await;
                 }
             }
         }

--- a/src/waiter.rs
+++ b/src/waiter.rs
@@ -1,9 +1,9 @@
 use crate::{ElementPoller, ElementPredicate};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use thirtyfour::error::WebDriverError;
 use thirtyfour::prelude::WebDriverResult;
+use thirtyfour::support::sleep;
 use thirtyfour::WebElement;
-use tokio::time::{delay_for, Instant};
 
 pub struct ElementWaiter<'a> {
     element: &'a WebElement<'a>,
@@ -104,7 +104,7 @@ impl<'a> ElementWaiter<'a> {
 
                 if actual_elapsed < minimum_elapsed {
                     // So we need to wait this much longer.
-                    delay_for(minimum_elapsed - actual_elapsed).await;
+                    sleep(minimum_elapsed - actual_elapsed).await;
                 }
             }
         }


### PR DESCRIPTION
To use thirtyfour_query with async-std, tokio must not be used in the code. This pull request replaces calls to tokio's `delay_for` with calls to `sleep` from thirtyfour's support module which delegates it to the appropriate runtime.